### PR TITLE
Passed main_form to included files in Cart/Summery/items.html.twig

### DIFF
--- a/SyliusShopBundle/views/Cart/Summary/_items.html.twig
+++ b/SyliusShopBundle/views/Cart/Summary/_items.html.twig
@@ -17,7 +17,7 @@
             </thead>
             <tbody>
                 {% for key, item in cart.items %}
-                    {% include '@SyliusShop/Cart/Summary/_item.html.twig' with {'item': item, 'form': form.items[key]} %}
+                    {% include '@SyliusShop/Cart/Summary/_item.html.twig' with {'item': item, 'form': form.items[key], 'main_form': form.vars.id} %}
                 {% endfor %}
             </tbody>
         </table>
@@ -30,7 +30,7 @@
                 {% endif %}
 
                 <div class="col text-right">
-                    {% include '@SyliusShop/Cart/Summary/_update.html.twig' %}
+                    {% include '@SyliusShop/Cart/Summary/_update.html.twig' with {'main_form': form.vars.id} %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master 
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

The standard sylius template passes a main_form variable to the included files. The bootstrapTheme version only passes it for the coupon. While the other two included files don't use the variable in the BootstrapTheme, it can cause some problems with other Bundles/Plugins that use it. 
There is not downside to passing it to the other files as well. As it only creates easier access to the variable and makes updating the templates a bit easier. Which reduces the required amount of manual labor to integrate other bundles and plugins if they use the main_form variable in their templates.

The Bundle were I run into such a case: Brille24/SyliusCustomOptionsPlugin 
in the ShopBundle/Cart/Summery/item.html.twig template
