### PR TITLE
[Front dependencies] Add missing popper.js deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Master is compatible with Sylius 1.8, 1.9 and 1.10.
     ```bash
     yarn
     yarn add @symfony/webpack-encore sass-loader@^7.0.0 node-sass lodash.throttle -D
-    yarn add bootstrap@^4.5.0 bootstrap.native@^3.0.0 glightbox axios form-serialize @fortawesome/fontawesome-svg-core @fortawesome/free-brands-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons
+    yarn add bootstrap@^4.5.0 bootstrap.native@^3.0.0 glightbox axios form-serialize @fortawesome/fontawesome-svg-core @fortawesome/free-brands-svg-icons @fortawesome/free-regular-svg-icons @fortawesome/free-solid-svg-icons popper.js
     ```
 
 4. Import bootstrap-theme config in the main webpack file


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no <!-- don't forget to update the UPGRADE-*.md file -->
| Related tickets | N/A
| License         | MIT

Hi :wave: 

Since https://github.com/SyliusCrafts/BootstrapTheme/commit/a3d96febeb8903c0c3c8c1c595ba9ee004d9c9cc,  our build is broken cause this missing dependency :upside_down_face: 

Let's add it in the readme
