### PR TITLE
Use picsum.photos only when product has no image

### DIFF
--- a/templates/bundles/SyliusShopBundle/Product/_mainImage.html.twig
+++ b/templates/bundles/SyliusShopBundle/Product/_mainImage.html.twig
@@ -3,9 +3,9 @@
 {% elseif product.images.first %}
     {% set path = product.images.first.path|imagine_filter(filter|default('sylius_shop_product_thumbnail')) %}
 {% else %}
-{% endif %}
     {% set size = random(5) * 200 %}
     {% set path = "https://picsum.photos/#{ size }/#{ size }.jpg" %}
+{% endif %}
 
 <div class="ratio ratio-1x1">
     <img src="{{ path }}" alt="{{ product.name }}" class="{{ class|default('') }} object-fit-cover rounded-3 border border-light bg-light" {{ sylius_test_html_attribute('main-image') }} />


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | master <!-- see the comment below -->
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT

